### PR TITLE
Correctly export gradle-wrapper.jar

### DIFF
--- a/src/main/java/robotbuilder/exporters/ExportFile.java
+++ b/src/main/java/robotbuilder/exporters/ExportFile.java
@@ -53,7 +53,7 @@ public class ExportFile {
         // Export
         if (!export.exists() || update.equals("Overwrite") || !newType.equals(oldType)) {
             System.out.println("Overwriting " + export);
-			if (isBinaryFile) {
+            if (isBinaryFile) {
                 // Don't attempt to parse binary files - they get corrupted if run through Velocity
                 IOUtils.copy(Utils.getResourceAsStream(source), Files.newOutputStream(export.toPath()));
             } else {

--- a/src/main/java/robotbuilder/exporters/ExportFile.java
+++ b/src/main/java/robotbuilder/exporters/ExportFile.java
@@ -45,14 +45,15 @@ public class ExportFile {
             newProject = mkdir(export.getParentFile());
         }
 
+        boolean isBinaryFile = export.getName().endsWith(".jar") || export.getName().endsWith(".notjar");
         String oldType = CodeFileUtils.getSavedSuperclass(export);
-        String newType = CodeFileUtils.getSavedSuperclass(exporter.evalResource(source, fileContext));
+        String newType = isBinaryFile ? oldType : CodeFileUtils.getSavedSuperclass(exporter.evalResource(source, fileContext));
         System.out.println("Saved type: " + oldType);
         System.out.println("  New type: " + newType);
         // Export
         if (!export.exists() || update.equals("Overwrite") || !newType.equals(oldType)) {
             System.out.println("Overwriting " + export);
-            if (export.getName().endsWith(".jar")) {
+			if (isBinaryFile) {
                 // Don't attempt to parse binary files - they get corrupted if run through Velocity
                 IOUtils.copy(Utils.getResourceAsStream(source), Files.newOutputStream(export.toPath()));
             } else {


### PR DESCRIPTION
The original code fails when trying to export the gradle/wrapper/gradle-wrapper.jar file, because it attempts to parse that file to determine the file type. 

This change identifies the *.jar /  *.notjar files as binary, and then does not parse them.